### PR TITLE
Make staging repository operations retry on failure

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -31,25 +31,25 @@ object Deps {
 }
 
 class Publish(val crossScalaVersion: String) extends CrossScalaModule with Published {
-  def ivyDeps = super.ivyDeps() ++ Seq(
+  override def ivyDeps = super.ivyDeps() ++ Seq(
     Deps.coursierCache,
     Deps.coursierCore,
     Deps.collectionCompat,
     Deps.jsoniterCore,
     Deps.sttp
   )
-  def compileIvyDeps = super.compileIvyDeps() ++ Seq(
+  override def compileIvyDeps = super.compileIvyDeps() ++ Seq(
     Deps.jsoniterMacros
   )
-  def javacOptions = super.javacOptions() ++ Seq(
+  override def javacOptions = super.javacOptions() ++ Seq(
     "--release",
     "8"
   )
   object test extends Tests {
-    def ivyDeps = super.ivyDeps() ++ Seq(
+    override def ivyDeps = super.ivyDeps() ++ Seq(
       Deps.utest
     )
-    def testFramework = "utest.runner.Framework"
+    override def testFramework = "utest.runner.Framework"
   }
 }
 

--- a/build.sc
+++ b/build.sc
@@ -31,25 +31,25 @@ object Deps {
 }
 
 class Publish(val crossScalaVersion: String) extends CrossScalaModule with Published {
-  override def ivyDeps = super.ivyDeps() ++ Seq(
+  def ivyDeps = super.ivyDeps() ++ Seq(
     Deps.coursierCache,
     Deps.coursierCore,
     Deps.collectionCompat,
     Deps.jsoniterCore,
     Deps.sttp
   )
-  override def compileIvyDeps = super.compileIvyDeps() ++ Seq(
+  def compileIvyDeps = super.compileIvyDeps() ++ Seq(
     Deps.jsoniterMacros
   )
-  override def javacOptions = super.javacOptions() ++ Seq(
+  def javacOptions = super.javacOptions() ++ Seq(
     "--release",
     "8"
   )
   object test extends Tests {
-    override def ivyDeps = super.ivyDeps() ++ Seq(
+    def ivyDeps = super.ivyDeps() ++ Seq(
       Deps.utest
     )
-    override def testFramework = "utest.runner.Framework"
+    def testFramework = "utest.runner.Framework"
   }
 }
 

--- a/publish/src/coursier/publish/sonatype/HttpClientUtil.scala
+++ b/publish/src/coursier/publish/sonatype/HttpClientUtil.scala
@@ -56,7 +56,15 @@ private[sonatype] final case class HttpClientUtil(
     }
   }
 
-  def create(
+  def create(url: String, post: Option[Array[Byte]] = None, isJson: Boolean = false): Unit = {
+    val resp = createResponse(url, post, isJson)
+    if (resp.code.code != 201)
+      throw new Exception(
+        s"Failed to get $url (http status: ${resp.code.code}, response: ${Try(new String(resp.body, StandardCharsets.UTF_8)).getOrElse("")})"
+      )
+  }
+
+  def createResponse(
     url: String,
     post: Option[Array[Byte]] = None,
     isJson: Boolean = false

--- a/publish/src/coursier/publish/sonatype/HttpClientUtil.scala
+++ b/publish/src/coursier/publish/sonatype/HttpClientUtil.scala
@@ -56,18 +56,18 @@ private[sonatype] final case class HttpClientUtil(
     }
   }
 
-  def create(url: String, post: Option[Array[Byte]] = None, isJson: Boolean = false): Unit = {
-
+  def create(
+    url: String,
+    post: Option[Array[Byte]] = None,
+    isJson: Boolean = false
+  ): Response[Array[Byte]] = {
     if (verbosity >= 1)
       Console.err.println(s"Getting $url")
     val resp = request(url, post, isJson).send(backend)
     if (verbosity >= 1)
-      Console.err.println(s"Done: $url")
+      Console.err.println(s"Got HTTP ${resp.code.code} from $url")
 
-    if (resp.code.code != 201)
-      throw new Exception(
-        s"Failed to get $url (http status: ${resp.code.code}, response: ${Try(new String(resp.body, StandardCharsets.UTF_8)).getOrElse("")})"
-      )
+    resp
   }
 
   def get[T: JsonValueCodec](

--- a/publish/src/coursier/publish/sonatype/SonatypeApi.scala
+++ b/publish/src/coursier/publish/sonatype/SonatypeApi.scala
@@ -133,7 +133,7 @@ final case class SonatypeApi(
     val body = postBody(writeToArray(StagedRepositoryRequest(description, repositoryId)))
     @tailrec
     def sendRequest(attempt: Int): Unit = {
-      val resp = clientUtil.create(url, post = Some(body), isJson = true)
+      val resp = clientUtil.createResponse(url, post = Some(body), isJson = true)
 
       if (!resp.code.isSuccess) {
         if (attempt >= stagingRepoRetries)

--- a/publish/src/coursier/publish/sonatype/SonatypeApi.scala
+++ b/publish/src/coursier/publish/sonatype/SonatypeApi.scala
@@ -7,11 +7,12 @@ import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros._
 import coursier.core.Authentication
 import coursier.publish.sonatype.logger.SonatypeLogger
+import coursier.publish.util.EmaRetryParams
 import coursier.util.Task
 import sttp.client3._
 
 import scala.annotation.tailrec
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -21,7 +22,7 @@ final case class SonatypeApi(
   authentication: Option[Authentication],
   verbosity: Int,
   retryOnTimeout: Int = 3,
-  stagingRepoRetries: Int = 3
+  stagingRepoRetryParams: EmaRetryParams = EmaRetryParams(3, 10.seconds.toMillis, 2.0f)
 ) {
 
   // vaguely inspired by https://github.com/lihaoyi/mill/blob/7b4ced648ecd9b79b3a16d67552f0bb69f4dd543/scalalib/src/mill/scalalib/publish/SonatypeHttpApi.scala
@@ -132,21 +133,21 @@ final case class SonatypeApi(
     val url  = s"${profile.uri}/$action"
     val body = postBody(writeToArray(StagedRepositoryRequest(description, repositoryId)))
     @tailrec
-    def sendRequest(attempt: Int): Unit = {
+    def sendRequest(attempt: Int, waitDurationMs: Long): Unit = {
       val resp = clientUtil.createResponse(url, post = Some(body), isJson = true)
 
       if (!resp.code.isSuccess) {
-        if (attempt >= stagingRepoRetries)
+        if (attempt >= stagingRepoRetryParams.attempts)
           throw new Exception(
             s"Failed to get $url (http status: ${resp.code.code}, response: ${Try(new String(resp.body, StandardCharsets.UTF_8)).getOrElse("")})"
           )
 
-        Thread.sleep(1000 * attempt)
-        sendRequest(attempt + 1)
+        Thread.sleep(waitDurationMs)
+        sendRequest(attempt + 1, stagingRepoRetryParams.update(waitDurationMs))
       }
     }
 
-    sendRequest(1)
+    sendRequest(1, stagingRepoRetryParams.initialWaitDurationMs)
   }
 
   def sendCloseStagingRepositoryRequest(

--- a/publish/src/coursier/publish/util/EmaRetryParams.scala
+++ b/publish/src/coursier/publish/util/EmaRetryParams.scala
@@ -1,0 +1,12 @@
+package coursier.publish.util
+
+import scala.math.Numeric.Implicits
+
+final case class EmaRetryParams(
+  attempts: Int,
+  initialWaitDurationMs: Long,
+  factor: Float
+) {
+  def update(value: Long): Long =
+    math.ceil(value * factor.toDouble).toLong
+}

--- a/publish/test/src/coursier/publish/sonatype/SonatypeTests.scala
+++ b/publish/test/src/coursier/publish/sonatype/SonatypeTests.scala
@@ -1,0 +1,63 @@
+package src.coursier.publish.sonatype
+
+import coursier.publish.sonatype.SonatypeApi
+import sttp.client3.testing.SttpBackendStub
+
+import utest._
+
+object SonatypeTests extends TestSuite {
+  val tests = Tests {
+    test("Retry sonatype repository actions") {
+      var count = 0
+      val mockBackend = SttpBackendStub.synchronous
+        .whenRequestMatches { _ => count += 1; count < 6 }
+        .thenRespondServerError()
+        .whenRequestMatches(_ => count >= 6)
+        .thenRespondOk()
+
+      {
+        val sonatypeApi20 = SonatypeApi(
+          mockBackend,
+          base = "https://oss.sonatype.org",
+          authentication = None,
+          verbosity = 0,
+          retryOnTimeout = 1,
+          stagingRepoRetries = 20
+        )
+
+        sonatypeApi20.sendPromoteStagingRepositoryRequest(
+          SonatypeApi.Profile("id", "name", "uri"),
+          "repo",
+          "description"
+        )
+
+        assert(count == 6)
+      }
+
+      count = 0
+
+      {
+        val sonatypeApi3 = SonatypeApi(
+          mockBackend,
+          base = "https://oss.sonatype.org",
+          authentication = None,
+          verbosity = 0,
+          retryOnTimeout = 1
+        )
+
+        try sonatypeApi3.sendPromoteStagingRepositoryRequest(
+          SonatypeApi.Profile("id", "name", "uri"),
+          "repo",
+          "description"
+        )
+        catch {
+          case e: Exception
+              if e.getMessage == "Failed to get uri/promote (http status: 500, response: Internal server error)" =>
+          case _: Throwable => assert(false)
+        }
+
+        assert(count == 3)
+      }
+    }
+  }
+}

--- a/publish/test/src/coursier/publish/sonatype/SonatypeTests.scala
+++ b/publish/test/src/coursier/publish/sonatype/SonatypeTests.scala
@@ -1,6 +1,5 @@
 package coursier.publish.sonatype
 
-import coursier.publish.sonatype.SonatypeApi
 import coursier.publish.util.EmaRetryParams
 import sttp.client3.testing.SttpBackendStub
 

--- a/publish/test/src/coursier/publish/sonatype/SonatypeTests.scala
+++ b/publish/test/src/coursier/publish/sonatype/SonatypeTests.scala
@@ -1,4 +1,4 @@
-package src.coursier.publish.sonatype
+package coursier.publish.sonatype
 
 import coursier.publish.sonatype.SonatypeApi
 import coursier.publish.util.EmaRetryParams

--- a/publish/test/src/coursier/publish/sonatype/SonatypeTests.scala
+++ b/publish/test/src/coursier/publish/sonatype/SonatypeTests.scala
@@ -23,7 +23,7 @@ object SonatypeTests extends TestSuite {
           authentication = None,
           verbosity = 0,
           retryOnTimeout = 1,
-          stagingRepoRetryParams = EmaRetryParams(20, 10000L, 2.0f)
+          stagingRepoRetryParams = EmaRetryParams(20, 100L, 1.0f)
         )
 
         sonatypeApi20.sendPromoteStagingRepositoryRequest(

--- a/publish/test/src/coursier/publish/sonatype/SonatypeTests.scala
+++ b/publish/test/src/coursier/publish/sonatype/SonatypeTests.scala
@@ -1,6 +1,7 @@
 package src.coursier.publish.sonatype
 
 import coursier.publish.sonatype.SonatypeApi
+import coursier.publish.util.EmaRetryParams
 import sttp.client3.testing.SttpBackendStub
 
 import utest._
@@ -22,7 +23,7 @@ object SonatypeTests extends TestSuite {
           authentication = None,
           verbosity = 0,
           retryOnTimeout = 1,
-          stagingRepoRetries = 20
+          stagingRepoRetryParams = EmaRetryParams(20, 10000L, 2.0f)
         )
 
         sonatypeApi20.sendPromoteStagingRepositoryRequest(


### PR DESCRIPTION
Publishing to sonatype sometimes fails with response HTTP 500 `Unhandled: Staging repository is already transitioning`
This happens right after the staging repository changes its status to 'closed' and a request is sent to promote it to `release`.
Adding a 'retry' mechanism may solve the issue.